### PR TITLE
docs: deprecate reindex/backfill and ES-era query param docs (PPT-2644)

### DIFF
--- a/src/resources/interface.ts
+++ b/src/resources/interface.ts
@@ -6,20 +6,17 @@ import { HashMap } from '../utilities/types';
 /** Allowable query parameters for basic index endpoints */
 export interface PlaceResourceQueryOptions {
     /**
-     * Search filter supporting the following syntax
-     * https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
+     * Free-text search filter. Words match as prefixes against the resource's
+     * searchable fields (PostgreSQL full-text search); all words must match.
      */
     q?: string;
-    /**
-     * Comma separated list of fields to search.
-     * Accepts wildcard expressions and boost relevance scores using caret ^ operator.
-     */
+    /** @deprecated Ignored by the server since PlaceOS moved search to PostgreSQL (PPT-2644) */
     fields?: string;
-    /** Number of results to return. Defaults to `20`. Max `500` */
+    /** Number of results to return. Defaults to `20`. Max `10000` */
     limit?: number;
-    /** @deprecated Use `ref` for pagination. Offset of the results to return. Max `10000` */
+    /** Offset of the results to return. Max `1000000` */
     offset?: number;
-    /** Token for accessing the next page of results, provided in the `Link` header */
+    /** @deprecated Ignored by the server; pagination follows the `Link` header's offset */
     ref?: string;
     /** Number of milliseconds to cache the query response */
     cache?: number;

--- a/src/root/functions.ts
+++ b/src/root/functions.ts
@@ -40,7 +40,7 @@ export function signal(channel: string, body: HashMap = {}): Promise<void> {
     return post(`${apiEndpoint()}/signal?${q}`, body).then(() => undefined);
 }
 
-/** Recreate Elasticsearch indexes */
+/** @deprecated No-op since PlaceOS moved search to PostgreSQL (PPT-2644); will be removed */
 export function reindex(query_params: ReindexOptions = {}): Promise<void> {
     const q = toQueryString(query_params);
     return post(`${apiEndpoint()}/reindex${q ? '?' + q : ''}`, {}).then(
@@ -48,7 +48,7 @@ export function reindex(query_params: ReindexOptions = {}): Promise<void> {
     );
 }
 
-/** Push all database data into Elasticsearch */
+/** @deprecated No-op since PlaceOS moved search to PostgreSQL (PPT-2644); will be removed */
 export function backfill(): Promise<void> {
     return post(`${apiEndpoint()}/backfill`, {}).then(() => undefined);
 }


### PR DESCRIPTION
Part of [PPT-2644](https://acaprojects.atlassian.net/browse/PPT-2644): PlaceOS search moved from Elasticsearch to PostgreSQL full-text search (models#324/#325, rest-api#445 — merged). The ES-era admin endpoints `/reindex` and `/backfill` are now server-side 200 no-ops pending removal, and several index-endpoint query params changed meaning or stopped doing anything. This PR updates the SDK docs to match; it is **documentation/deprecation only — zero runtime change**.

## What

- `reindex()` and `backfill()` (`src/root/functions.ts`) are tagged `@deprecated` — they still call their endpoints (which return 200) so existing callers, including Backoffice's admin card, keep working. The methods themselves will be removed in the next ts-client major.
- `PlaceResourceQueryOptions` (`src/resources/interface.ts`) doc rewrites:
  - `q` — no longer ES `simple_query_string` syntax; words match as prefixes against the resource's searchable fields and **all words must match**.
  - `fields` — `@deprecated`, ignored by the server (was ES field-list/boost syntax).
  - `ref` — `@deprecated`, ignored by the server; pagination follows the `Link` header's offset.
  - `offset` — un-deprecated (it is the pagination mechanism again), max corrected to 1,000,000.
  - `limit` — max corrected from 500 to 10,000.

## Verification

- Type/doc-comment surface only; no emitted-code change beyond the `@deprecated` JSDoc tags.
- Full test suite green: 65 files, **546/546 tests passed** (vitest).

## Merge order

Independent of the other PPT-2644 infra-removal PRs — safe to merge any time. Actual removal of `reindex()`/`backfill()` lands in the next ts-client major.


[PPT-2644]: https://acaprojects.atlassian.net/browse/PPT-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ