### PR TITLE
feat(signage): AI image generation functions (PPT-2741)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -512,6 +512,45 @@ export type {
 export { PlaceZone } from './zones/zone';
 
 export {
+    addSignageAIProvider,
+    cancelSignageAIJob,
+    claimSignageAIImage,
+    editSignageImage,
+    generateSignageImage,
+    querySignageAIJobs,
+    querySignageAIProviders,
+    removeSignageAIProvider,
+    showSignageAIJob,
+    showSignageAIProvider,
+    signageAICapabilities,
+    signageAIUsage,
+    testSignageAIProvider,
+    updateSignageAIProvider,
+} from './signage/ai/functions';
+export type {
+    SignageAICapabilities,
+    SignageAIClaimRequest,
+    SignageAIEditRequest,
+    SignageAIGenerateRequest,
+    SignageAIImage,
+    SignageAIJob,
+    SignageAIJobKind,
+    SignageAIJobQueryOptions,
+    SignageAIJobShowOptions,
+    SignageAIJobState,
+    SignageAIModelCapabilities,
+    SignageAIProvider,
+    SignageAIProviderCapabilities,
+    SignageAIProviderQueryOptions,
+    SignageAIProviderRequest,
+    SignageAIProviderTestResult,
+    SignageAIProviderType,
+    SignageAIQuota,
+    SignageAIUsageOptions,
+    SignageAIUsageRow,
+} from './signage/ai/interfaces';
+
+export {
     addSignageMedia,
     addSignagePlaylist,
     addSignagePlugin,

--- a/src/signage/ai/functions.ts
+++ b/src/signage/ai/functions.ts
@@ -1,0 +1,252 @@
+import { query, remove, show } from '../../api';
+import { apiEndpoint } from '../../auth';
+import { patch, post, put } from '../../http/functions';
+import { HttpJsonOptions } from '../../http/interfaces';
+import { task } from '../../resources/functions';
+import { HashMap } from '../../utilities/types';
+import {
+    SignageAICapabilities,
+    SignageAIClaimRequest,
+    SignageAIEditRequest,
+    SignageAIGenerateRequest,
+    SignageAIJob,
+    SignageAIJobQueryOptions,
+    SignageAIJobShowOptions,
+    SignageAIProvider,
+    SignageAIProviderQueryOptions,
+    SignageAIProviderRequest,
+    SignageAIProviderTestResult,
+    SignageAIUsageOptions,
+    SignageAIUsageRow,
+} from './interfaces';
+
+/**
+ * @private
+ */
+const PATH = 'signage/ai';
+
+/**
+ * @private
+ */
+const JOBS_PATH = 'signage/ai/jobs';
+
+/**
+ * @private
+ */
+const PROVIDERS_PATH = 'signage/ai/providers';
+
+/**
+ * Get what image generation can do on the current domain, and what the caller
+ * has left of their image allowance
+ */
+export function signageAICapabilities() {
+    return show<SignageAICapabilities>({
+        id: 'capabilities',
+        query_params: {},
+        fn: (response) => response as SignageAICapabilities,
+        path: PATH,
+    });
+}
+
+/**
+ * Start generating an image from a brief. Answers as soon as the job is
+ * accepted, long poll `showSignageAIJob` for the candidates
+ * @param request Brief and generation settings
+ */
+export function generateSignageImage(request: SignageAIGenerateRequest) {
+    return post(`${apiEndpoint()}/${PATH}/generate`, request).then(
+        (response) => response as unknown as SignageAIJob,
+    );
+}
+
+/**
+ * Start editing an existing image, or refining an earlier job. Answers as soon
+ * as the job is accepted, long poll `showSignageAIJob` for the candidates
+ * @param request Instruction, source image and generation settings
+ */
+export function editSignageImage(request: SignageAIEditRequest) {
+    return post(`${apiEndpoint()}/${PATH}/edit`, request).then(
+        (response) => response as unknown as SignageAIJob,
+    );
+}
+
+/**
+ * Get an image generation job, optionally holding the request open until the
+ * job changes.
+ *
+ * Uses `show` rather than `query` on purpose: a `wait` of up to 25 seconds must
+ * not be served from the query dedupe cache, or two pollers share one response
+ * and one of them waits twice as long as it asked to. Pass
+ * `{ skip_auth_flow: true }` as `options` to stop a failed poll being retried
+ * four times before it rejects
+ * @param id ID of the job
+ * @param query_params Query parameters to add the to request URL
+ * @param options Options to add to the request
+ */
+export function showSignageAIJob(
+    id: string,
+    query_params: SignageAIJobShowOptions = {},
+    options?: HttpJsonOptions,
+) {
+    return show<SignageAIJob>({
+        id,
+        query_params,
+        fn: (response) => response as SignageAIJob,
+        path: JOBS_PATH,
+        options,
+    });
+}
+
+/**
+ * List recent image generation jobs, for the recent generations list.
+ *
+ * The endpoint answers with a plain array rather than a paged index, and the
+ * list is polled alongside the jobs themselves, so this uses `show` to stay out
+ * of the query dedupe cache
+ * @param query_params Query parameters to add the to request URL
+ */
+export function querySignageAIJobs(
+    query_params: SignageAIJobQueryOptions = {},
+) {
+    return show<SignageAIJob[]>({
+        id: 'jobs',
+        query_params,
+        fn: (response) => response as SignageAIJob[],
+        path: PATH,
+    });
+}
+
+/**
+ * Ask a running job to stop. Candidates already with the vendor run to
+ * completion, so the returned job may still gain images
+ * @param id ID of the job
+ */
+export function cancelSignageAIJob(id: string) {
+    return task<SignageAIJob>({
+        id,
+        task_name: 'cancel',
+        method: 'post',
+        path: JOBS_PATH,
+        callback: (response) => response as SignageAIJob,
+    });
+}
+
+/**
+ * Record that a candidate was kept as a media item, so the sweep that clears
+ * unused candidates leaves it alone
+ * @param id ID of the job the candidate belongs to
+ * @param request The candidate's upload and the media item now using it
+ */
+export function claimSignageAIImage(
+    id: string,
+    request: SignageAIClaimRequest,
+) {
+    return task<SignageAIJob>({
+        id,
+        task_name: 'claim',
+        form_data: request,
+        method: 'post',
+        path: JOBS_PATH,
+        callback: (response) => response as SignageAIJob,
+    });
+}
+
+/**
+ * Get image generation spend for the current domain, broken down by provider
+ * and model
+ * @param query_params Query parameters to add the to request URL
+ */
+export function signageAIUsage(query_params: SignageAIUsageOptions = {}) {
+    return show<SignageAIUsageRow[]>({
+        id: 'usage',
+        query_params,
+        fn: (response) => response as SignageAIUsageRow[],
+        path: PATH,
+    });
+}
+
+/** Convert raw server data to an AI provider object */
+function processProvider(item: Partial<SignageAIProvider>) {
+    return item as SignageAIProvider;
+}
+
+/**
+ * Query the configured AI providers
+ * @param query_params Query parameters to add the to request URL
+ */
+export function querySignageAIProviders(
+    query_params: SignageAIProviderQueryOptions = {},
+) {
+    return query({
+        query_params,
+        fn: processProvider,
+        path: PROVIDERS_PATH,
+    });
+}
+
+/**
+ * Get the details of an AI provider
+ * @param id ID of the provider
+ */
+export function showSignageAIProvider(id: string) {
+    return show({
+        id,
+        query_params: {},
+        fn: processProvider,
+        path: PROVIDERS_PATH,
+    });
+}
+
+/**
+ * Add a new AI provider
+ * @param form_data Provider details, including the vendor credentials
+ */
+export function addSignageAIProvider(form_data: SignageAIProviderRequest) {
+    return post(`${apiEndpoint()}/${PROVIDERS_PATH}`, form_data).then(
+        (response) => response as unknown as SignageAIProvider,
+    );
+}
+
+/**
+ * Update an AI provider. Leaving `credentials` out keeps the stored value.
+ *
+ * Bypasses the `update` helper because that appends `version` to the query
+ * string and provider rows are not versioned
+ * @param id ID of the provider
+ * @param form_data New values for the provider
+ * @param method HTTP verb to use on request. Defaults to `patch`
+ */
+export function updateSignageAIProvider(
+    id: string,
+    form_data: SignageAIProviderRequest,
+    method: 'put' | 'patch' = 'patch',
+) {
+    return (method === 'put' ? put : patch)(
+        `${apiEndpoint()}/${PROVIDERS_PATH}/${id}`,
+        form_data,
+    ).then((response: HashMap) => response as unknown as SignageAIProvider);
+}
+
+/**
+ * Remove an AI provider. Jobs it produced keep the vendor and model they
+ * recorded
+ * @param id ID of the provider
+ */
+export function removeSignageAIProvider(id: string) {
+    return remove({ id, query_params: {}, path: PROVIDERS_PATH });
+}
+
+/**
+ * Prove an AI provider's credentials work by generating one small image and
+ * discarding it
+ * @param id ID of the provider
+ */
+export function testSignageAIProvider(id: string) {
+    return task<SignageAIProviderTestResult>({
+        id,
+        task_name: 'test',
+        method: 'post',
+        path: PROVIDERS_PATH,
+        callback: (response) => response as SignageAIProviderTestResult,
+    });
+}

--- a/src/signage/ai/functions.ts
+++ b/src/signage/ai/functions.ts
@@ -74,11 +74,8 @@ export function editSignageImage(request: SignageAIEditRequest) {
  * Get an image generation job, optionally holding the request open until the
  * job changes.
  *
- * Uses `show` rather than `query` on purpose: a `wait` of up to 25 seconds must
- * not be served from the query dedupe cache, or two pollers share one response
- * and one of them waits twice as long as it asked to. Pass
- * `{ skip_auth_flow: true }` as `options` to stop a failed poll being retried
- * four times before it rejects
+ * Pass `{ skip_auth_flow: true }` as `options` to stop a failed poll being
+ * retried four times before it rejects
  * @param id ID of the job
  * @param query_params Query parameters to add the to request URL
  * @param options Options to add to the request
@@ -99,10 +96,6 @@ export function showSignageAIJob(
 
 /**
  * List recent image generation jobs, for the recent generations list.
- *
- * The endpoint answers with a plain array rather than a paged index, and the
- * list is polled alongside the jobs themselves, so this uses `show` to stay out
- * of the query dedupe cache
  * @param query_params Query parameters to add the to request URL
  */
 export function querySignageAIJobs(
@@ -209,9 +202,6 @@ export function addSignageAIProvider(form_data: SignageAIProviderRequest) {
 
 /**
  * Update an AI provider. Leaving `credentials` out keeps the stored value.
- *
- * Bypasses the `update` helper because that appends `version` to the query
- * string and provider rows are not versioned
  * @param id ID of the provider
  * @param form_data New values for the provider
  * @param method HTTP verb to use on request. Defaults to `patch`

--- a/src/signage/ai/interfaces.ts
+++ b/src/signage/ai/interfaces.ts
@@ -294,9 +294,6 @@ export interface SignageAIProviderRequest {
 
 /**
  * Allowable query parameters for the AI providers index endpoint.
- *
- * There is no domain parameter: the endpoint answers for the domain the request
- * is made against, and another domain's rows are not reachable.
  */
 export interface SignageAIProviderQueryOptions {
     /** Include the shared fallback row. Defaults to `true` */

--- a/src/signage/ai/interfaces.ts
+++ b/src/signage/ai/interfaces.ts
@@ -1,0 +1,317 @@
+/** Vendors an AI provider row can be pointed at */
+export type SignageAIProviderType = 'OPENAI' | 'AZURE_OPENAI' | 'GOOGLE_VERTEX';
+
+/** Lifecycle of an image generation job */
+export type SignageAIJobState =
+    | 'queued'
+    | 'running'
+    | 'done'
+    | 'failed'
+    | 'cancelled';
+
+/** Whether a job started from a prompt alone or from an existing image */
+export type SignageAIJobKind = 'generate' | 'edit';
+
+/** What a single model on a provider is able to do */
+export interface SignageAIModelCapabilities {
+    /** Vendor identifier for the model, sent back as `model` on a request */
+    id: string;
+    /** Display name for the model */
+    name: string;
+    /** Model can create an image from a prompt alone */
+    generate: boolean;
+    /** Model can edit a supplied source image */
+    edit: boolean;
+    /** Model can enhance an image without a new brief */
+    enhance: boolean;
+    /** Maximum number of reference images accepted in one request */
+    max_references: number;
+    /** Maximum number of candidates the model will return in one request */
+    max_candidates: number;
+    /** Quality levels the model accepts */
+    qualities: string[];
+    /** Aspect ratios the model accepts */
+    aspect_ratios: string[];
+}
+
+/** A configured provider as seen by a user, without its credentials */
+export interface SignageAIProviderCapabilities {
+    /** ID of the provider row */
+    id: string;
+    /** Display name for the provider */
+    name: string;
+    /** Vendor the provider talks to */
+    provider: SignageAIProviderType;
+    /** Vendor region the provider is deployed in, when it has one */
+    region?: string;
+    /** Model used when a request does not name one */
+    default_model?: string;
+    /** Models available on this provider */
+    models: SignageAIModelCapabilities[];
+}
+
+/** Images the caller has left of their allowance. `null` when the feature is off */
+export interface SignageAIQuota {
+    /** Candidates the current user may still request today */
+    user_remaining_today: number | null;
+    /** Candidates the current domain may still request this month */
+    domain_remaining_month: number | null;
+}
+
+/** What image generation can do on the current domain, and for the current user */
+export interface SignageAICapabilities {
+    /** Whether image generation can be used at all */
+    enabled: boolean;
+    /** Why the feature is unavailable. Only set when `enabled` is false */
+    reason?: string;
+    /** Providers configured for this domain */
+    providers: SignageAIProviderCapabilities[];
+    /** ID of the provider used when a request does not name one */
+    default_provider_id?: string;
+    /** Aspect ratios accepted across the platform */
+    aspect_ratios: string[];
+    /** Quality levels accepted across the platform */
+    qualities: string[];
+    /** Most candidates that may be asked for in one request */
+    max_candidates: number;
+    /** Whether the domain has a logo that can be composited over a generated image */
+    logo_layer: boolean;
+    /** Remaining allowance for the caller and their domain */
+    quota: SignageAIQuota;
+}
+
+/**
+ * One candidate produced by a job. Slots are `null` in `SignageAIJob.images`
+ * until the candidate for that slot lands
+ */
+export interface SignageAIImage {
+    /** State of the candidate */
+    state: string;
+    /** Position of the candidate in the job's image list */
+    index: number;
+    /** ID of the upload holding the image */
+    upload_id: string;
+    /** Endpoint returning a signed URL for the image */
+    url: string;
+    /** Width of the image in pixels, when it could be read */
+    width: number | null;
+    /** Height of the image in pixels, when it could be read */
+    height: number | null;
+    /** Content type of the stored image */
+    mime: string;
+    /** Size of the stored image in bytes */
+    bytes: number;
+    /** ID of the media item the candidate was kept as. Set by claiming the image */
+    item_id?: string;
+}
+
+/** An image generation or edit job */
+export interface SignageAIJob {
+    /** ID of the job */
+    id: string;
+    /** Lifecycle state of the job */
+    state: SignageAIJobState;
+    /** Whether the job generates or edits */
+    kind: SignageAIJobKind;
+    /** Vendor the job was sent to */
+    provider?: SignageAIProviderType;
+    /** Model the job was sent to */
+    model?: string;
+    /** Number of candidates asked for */
+    candidates: number;
+    /** Number of candidates that have landed so far */
+    images_produced: number;
+    /** ID of the job this one refines, when it is a refine */
+    parent_job_id?: string;
+    /**
+     * Bumped on every change to the job. Pass it back as `since` when long
+     * polling so the request only returns once something new has landed
+     */
+    version: number;
+    /** Brief the user asked for */
+    prompt?: string;
+    /** Candidate slots in order, `null` until that candidate lands */
+    images: (SignageAIImage | null)[];
+    /** Class of failure, when the job failed */
+    error_kind?: string;
+    /** Description of the failure, when the job failed */
+    error_message?: string;
+    /** Vendor spend attributed to the job */
+    cost_units?: number;
+    /** Time the job took, in milliseconds */
+    latency_ms?: number;
+    /** Unix epoch in seconds at which the job was accepted */
+    created_at?: number;
+    /** Unix epoch in seconds at which the job stopped */
+    finished_at?: number;
+}
+
+/** Body of a request to generate an image from a brief */
+export interface SignageAIGenerateRequest {
+    /** What the image should show. Required */
+    prompt: string;
+    /** Shape of the image. Defaults to `16:9` */
+    aspect_ratio?: string;
+    /** Quality level to ask the vendor for. Defaults to `standard` */
+    quality?: string;
+    /** Number of candidates to produce. Clamped to the platform maximum */
+    candidates?: number;
+    /** IDs of uploads to hand the vendor as visual references */
+    references?: string[];
+    /** Composite the domain logo over the result. Defaults to `true` */
+    include_logo?: boolean;
+    /** Keep wording out of the image so it can be laid over. Defaults to `true` */
+    add_text_with_layer?: boolean;
+    /** Wording the image is being made for, used to leave room for it */
+    words?: string;
+    /** Provider to use. Defaults to the domain's default provider */
+    provider_id?: string;
+    /** Model to use. Defaults to the provider's default model */
+    model?: string;
+    /** Signage group the caller is acting in. Required unless the caller is support */
+    group_id?: string;
+    /** Repeating a key returns the job it first created rather than spending again */
+    idempotency_key?: string;
+}
+
+/** Body of a request to edit an existing image, or refine an earlier job */
+export interface SignageAIEditRequest extends SignageAIGenerateRequest {
+    /** ID of the upload to edit. Required */
+    source_upload_id: string;
+    /** Media item proving the caller may read a source they do not own */
+    source_item_id?: string;
+    /** ID of the job being refined, so its brief carries into the new prompt */
+    parent_job_id?: string;
+}
+
+/** Body of a request recording that a candidate became a media item */
+export interface SignageAIClaimRequest {
+    /** ID of the candidate's upload */
+    upload_id: string;
+    /** ID of the media item now using the upload */
+    item_id: string;
+}
+
+/** Allowable query parameters for the AI job show endpoint */
+export interface SignageAIJobShowOptions {
+    /**
+     * Seconds to hold the request open until the job changes, up to `25`.
+     * Defaults to `0`, which answers immediately
+     */
+    wait?: number;
+    /** Version the caller already holds. Defaults to the job's current version */
+    since?: number;
+}
+
+/** Allowable query parameters for the AI jobs index endpoint */
+export interface SignageAIJobQueryOptions {
+    /** Only return the caller's own jobs. Defaults to `true` */
+    mine?: boolean;
+    /** Number of jobs to return. Clamped to `100`. Defaults to `20` */
+    limit?: number;
+}
+
+/** Allowable query parameters for the AI usage endpoint */
+export interface SignageAIUsageOptions {
+    /** Unix epoch in seconds to report from. Defaults to 30 days ago */
+    from?: number;
+    /** Unix epoch in seconds to report to. Defaults to now */
+    to?: number;
+}
+
+/** Spend on one provider and model over the reported period */
+export interface SignageAIUsageRow {
+    /** Vendor the jobs were sent to */
+    provider: string;
+    /** Model the jobs were sent to */
+    model: string;
+    /** Number of jobs */
+    jobs: number;
+    /** Candidates asked for across those jobs */
+    candidates: number;
+    /** Candidates that landed across those jobs */
+    images_produced: number;
+    /** Vendor spend attributed to those jobs */
+    cost_units: number;
+}
+
+/** A stored provider row. Credentials are never returned */
+export interface SignageAIProvider {
+    /** ID of the provider row */
+    id: string;
+    /** Display name for the provider */
+    name: string;
+    /** Vendor the provider talks to */
+    provider: SignageAIProviderType;
+    /** Domain the row belongs to. `null` on the shared fallback row */
+    authority_id: string | null;
+    /** Vendor endpoint, for deployments that have their own */
+    endpoint: string | null;
+    /** Vendor region, for deployments that have one */
+    location: string | null;
+    /** Model used when a request does not name one */
+    default_model: string | null;
+    /** Models this row may be asked for. Empty allows every model the vendor offers */
+    allowed_models: string[];
+    /** Whether the row may be used */
+    enabled: boolean;
+    /** Whether the row is the default for its domain */
+    is_default: boolean;
+    /** Per user and per domain image allowances */
+    quotas: Record<string, number>;
+    /** Unix epoch in seconds at which the row was created */
+    created_at: number;
+    /** Unix epoch in seconds at which the row was last changed */
+    updated_at: number;
+}
+
+/**
+ * Body of a request creating or updating a provider row. `credentials` is
+ * required on create; left out of an update the stored value is kept
+ */
+export interface SignageAIProviderRequest {
+    /** Display name for the provider */
+    name?: string;
+    /** Vendor the provider talks to */
+    provider?: SignageAIProviderType;
+    /** Domain the row belongs to. Leave unset for the shared fallback row */
+    authority_id?: string;
+    /** Vendor credentials, in the shape that vendor expects */
+    credentials?: Record<string, any>;
+    /** Vendor endpoint, for deployments that have their own */
+    endpoint?: string;
+    /** Vendor region, for deployments that have one */
+    location?: string;
+    /** Model used when a request does not name one */
+    default_model?: string;
+    /** Models this row may be asked for */
+    allowed_models?: string[];
+    /** Whether the row may be used */
+    enabled?: boolean;
+    /** Whether the row is the default for its domain */
+    is_default?: boolean;
+    /** Per user and per domain image allowances */
+    quotas?: Record<string, number>;
+}
+
+/** Allowable query parameters for the AI providers index endpoint */
+export interface SignageAIProviderQueryOptions {
+    /** Return the rows belonging to this domain */
+    authority_id?: string;
+    /** Include the shared fallback row. Defaults to `true` */
+    include_shared?: boolean;
+}
+
+/** Outcome of proving a provider row's credentials work */
+export interface SignageAIProviderTestResult {
+    /** Whether the vendor answered with an image */
+    ok: boolean;
+    /** Time the vendor took, in milliseconds */
+    latency_ms: number;
+    /** Model the test was run against */
+    model?: string;
+    /** Description of the failure, when the test failed */
+    error?: string;
+    /** Class of failure, when the test failed */
+    kind?: string;
+}

--- a/src/signage/ai/interfaces.ts
+++ b/src/signage/ai/interfaces.ts
@@ -243,7 +243,7 @@ export interface SignageAIProvider {
     name: string;
     /** Vendor the provider talks to */
     provider: SignageAIProviderType;
-    /** Domain the row belongs to. `null` on the shared fallback row */
+    /** Domain the row belongs to, set by the server. `null` on the shared row */
     authority_id: string | null;
     /** Vendor endpoint, for deployments that have their own */
     endpoint: string | null;
@@ -274,8 +274,6 @@ export interface SignageAIProviderRequest {
     name?: string;
     /** Vendor the provider talks to */
     provider?: SignageAIProviderType;
-    /** Domain the row belongs to. Leave unset for the shared fallback row */
-    authority_id?: string;
     /** Vendor credentials, in the shape that vendor expects */
     credentials?: Record<string, any>;
     /** Vendor endpoint, for deployments that have their own */
@@ -294,10 +292,13 @@ export interface SignageAIProviderRequest {
     quotas?: Record<string, number>;
 }
 
-/** Allowable query parameters for the AI providers index endpoint */
+/**
+ * Allowable query parameters for the AI providers index endpoint.
+ *
+ * There is no domain parameter: the endpoint answers for the domain the request
+ * is made against, and another domain's rows are not reachable.
+ */
 export interface SignageAIProviderQueryOptions {
-    /** Return the rows belonging to this domain */
-    authority_id?: string;
     /** Include the shared fallback row. Defaults to `true` */
     include_shared?: boolean;
 }

--- a/test/signage/ai/functions.spec.ts
+++ b/test/signage/ai/functions.spec.ts
@@ -1,0 +1,303 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import * as Auth from '../../../src/auth';
+import * as Http from '../../../src/http/functions';
+import * as Resources from '../../../src/resources/functions';
+import * as SERVICE from '../../../src/signage/ai/functions';
+
+describe('Signage AI API', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('should allow listing AI capabilities', async () => {
+        const spy = vi.spyOn(Resources, 'show');
+        spy.mockImplementation((_) =>
+            Promise.resolve(
+                _.fn!({
+                    enabled: true,
+                    providers: [],
+                    aspect_ratios: ['16:9'],
+                    qualities: ['standard'],
+                    max_candidates: 4,
+                    logo_layer: true,
+                    quota: {
+                        user_remaining_today: 12,
+                        domain_remaining_month: 400,
+                    },
+                }) as any,
+            ),
+        );
+
+        const capabilities = await SERVICE.signageAICapabilities();
+
+        expect(capabilities.enabled).toBe(true);
+        expect(capabilities.quota.user_remaining_today).toBe(12);
+        expect(spy).toHaveBeenCalledWith({
+            id: 'capabilities',
+            query_params: {},
+            fn: expect.any(Function),
+            path: 'signage/ai',
+        });
+    });
+
+    test('should allow generating an image', async () => {
+        vi.spyOn(Auth, 'apiEndpoint').mockReturnValue('/api/engine/v2');
+        const spy = vi.spyOn(Http, 'post');
+        spy.mockResolvedValue({ id: 'job-123', state: 'queued' } as any);
+
+        const request = {
+            prompt: 'A quiet foyer at dawn',
+            aspect_ratio: '16:9',
+            candidates: 2,
+            group_id: 'group-123',
+            idempotency_key: 'key-123',
+        };
+        const job = await SERVICE.generateSignageImage(request);
+
+        expect(job.id).toBe('job-123');
+        expect(spy).toHaveBeenCalledWith(
+            '/api/engine/v2/signage/ai/generate',
+            request,
+        );
+    });
+
+    test('should allow editing an image', async () => {
+        vi.spyOn(Auth, 'apiEndpoint').mockReturnValue('/api/engine/v2');
+        const spy = vi.spyOn(Http, 'post');
+        spy.mockResolvedValue({ id: 'job-456', kind: 'edit' } as any);
+
+        const request = {
+            prompt: 'Warmer light',
+            source_upload_id: 'upload-123',
+            source_item_id: 'item-123',
+            parent_job_id: 'job-123',
+            group_id: 'group-123',
+        };
+        const job = await SERVICE.editSignageImage(request);
+
+        expect(job.kind).toBe('edit');
+        expect(spy).toHaveBeenCalledWith(
+            '/api/engine/v2/signage/ai/edit',
+            request,
+        );
+    });
+
+    test('should long poll an AI job without the query cache', async () => {
+        const spy = vi.spyOn(Resources, 'show');
+        spy.mockImplementation((_) =>
+            Promise.resolve(_.fn!({ id: 'job-123', version: 4 }) as any),
+        );
+
+        const job = await SERVICE.showSignageAIJob(
+            'job-123',
+            { wait: 25, since: 3 },
+            { skip_auth_flow: true },
+        );
+
+        expect(job.version).toBe(4);
+        expect(spy).toHaveBeenCalledWith({
+            id: 'job-123',
+            query_params: { wait: 25, since: 3 },
+            fn: expect.any(Function),
+            path: 'signage/ai/jobs',
+            options: { skip_auth_flow: true },
+        });
+    });
+
+    test('should allow listing recent AI jobs', async () => {
+        const spy = vi.spyOn(Resources, 'show');
+        spy.mockImplementation((_) =>
+            Promise.resolve(_.fn!([{ id: 'job-123' }]) as any),
+        );
+
+        const jobs = await SERVICE.querySignageAIJobs({ mine: true, limit: 5 });
+
+        expect(jobs.length).toBe(1);
+        expect(jobs[0].id).toBe('job-123');
+        expect(spy).toHaveBeenCalledWith({
+            id: 'jobs',
+            query_params: { mine: true, limit: 5 },
+            fn: expect.any(Function),
+            path: 'signage/ai',
+        });
+    });
+
+    test('should allow cancelling and claiming AI jobs', async () => {
+        const spy = vi.spyOn(Resources, 'task');
+        spy.mockImplementation((_) =>
+            Promise.resolve(_.callback!({ id: _.id }) as any),
+        );
+
+        const cancelled = await SERVICE.cancelSignageAIJob('job-123');
+        const claimed = await SERVICE.claimSignageAIImage('job-123', {
+            upload_id: 'upload-123',
+            item_id: 'item-123',
+        });
+
+        expect(cancelled.id).toBe('job-123');
+        expect(claimed.id).toBe('job-123');
+        expect(spy).toHaveBeenNthCalledWith(1, {
+            id: 'job-123',
+            task_name: 'cancel',
+            method: 'post',
+            path: 'signage/ai/jobs',
+            callback: expect.any(Function),
+        });
+        expect(spy).toHaveBeenNthCalledWith(2, {
+            id: 'job-123',
+            task_name: 'claim',
+            form_data: { upload_id: 'upload-123', item_id: 'item-123' },
+            method: 'post',
+            path: 'signage/ai/jobs',
+            callback: expect.any(Function),
+        });
+    });
+
+    test('should allow listing AI usage', async () => {
+        const spy = vi.spyOn(Resources, 'show');
+        spy.mockImplementation((_) =>
+            Promise.resolve(
+                _.fn!([
+                    {
+                        provider: 'OPENAI',
+                        model: 'gpt-image-1',
+                        jobs: 3,
+                        candidates: 6,
+                        images_produced: 6,
+                        cost_units: 0.42,
+                    },
+                ]) as any,
+            ),
+        );
+
+        const usage = await SERVICE.signageAIUsage({ from: 1, to: 2 });
+
+        expect(usage[0].cost_units).toBe(0.42);
+        expect(spy).toHaveBeenCalledWith({
+            id: 'usage',
+            query_params: { from: 1, to: 2 },
+            fn: expect.any(Function),
+            path: 'signage/ai',
+        });
+    });
+
+    test('should allow querying AI providers', async () => {
+        const spy = vi.spyOn(Resources, 'query');
+        spy.mockImplementation((_) =>
+            Promise.resolve({
+                total: 1,
+                next: () => null,
+                data: [_.fn!({ id: 'provider-123' })],
+            }),
+        );
+
+        const result = await SERVICE.querySignageAIProviders({
+            authority_id: 'authority-123',
+            include_shared: false,
+        });
+
+        expect(result.data[0].id).toBe('provider-123');
+        expect(spy).toHaveBeenCalledWith({
+            query_params: {
+                authority_id: 'authority-123',
+                include_shared: false,
+            },
+            fn: expect.any(Function),
+            path: 'signage/ai/providers',
+        });
+    });
+
+    test('should allow showing an AI provider', async () => {
+        const spy = vi.spyOn(Resources, 'show');
+        spy.mockImplementation((_) =>
+            Promise.resolve(_.fn!({ id: 'provider-123' }) as any),
+        );
+
+        const provider = await SERVICE.showSignageAIProvider('provider-123');
+
+        expect(provider.id).toBe('provider-123');
+        expect(spy).toHaveBeenCalledWith({
+            id: 'provider-123',
+            query_params: {},
+            fn: expect.any(Function),
+            path: 'signage/ai/providers',
+        });
+    });
+
+    test('should allow adding an AI provider', async () => {
+        vi.spyOn(Auth, 'apiEndpoint').mockReturnValue('/api/engine/v2');
+        const spy = vi.spyOn(Http, 'post');
+        spy.mockResolvedValue({ id: 'provider-123' } as any);
+
+        const form_data = {
+            name: 'OpenAI',
+            provider: 'OPENAI' as const,
+            credentials: { api_key: 'secret' },
+        };
+        const provider = await SERVICE.addSignageAIProvider(form_data);
+
+        expect(provider.id).toBe('provider-123');
+        expect(spy).toHaveBeenCalledWith(
+            '/api/engine/v2/signage/ai/providers',
+            form_data,
+        );
+    });
+
+    test('should update an AI provider without a version', async () => {
+        vi.spyOn(Auth, 'apiEndpoint').mockReturnValue('/api/engine/v2');
+        const patch_spy = vi.spyOn(Http, 'patch');
+        patch_spy.mockResolvedValue({ id: 'provider-123' } as any);
+        const put_spy = vi.spyOn(Http, 'put');
+        put_spy.mockResolvedValue({ id: 'provider-123' } as any);
+
+        await SERVICE.updateSignageAIProvider('provider-123', {
+            enabled: false,
+        });
+        await SERVICE.updateSignageAIProvider(
+            'provider-123',
+            { enabled: true },
+            'put',
+        );
+
+        expect(patch_spy).toHaveBeenCalledWith(
+            '/api/engine/v2/signage/ai/providers/provider-123',
+            { enabled: false },
+        );
+        expect(put_spy).toHaveBeenCalledWith(
+            '/api/engine/v2/signage/ai/providers/provider-123',
+            { enabled: true },
+        );
+    });
+
+    test('should allow removing an AI provider', async () => {
+        const spy = vi.spyOn(Resources, 'remove');
+        spy.mockResolvedValue({});
+
+        await SERVICE.removeSignageAIProvider('provider-123');
+
+        expect(spy).toHaveBeenCalledWith({
+            id: 'provider-123',
+            query_params: {},
+            path: 'signage/ai/providers',
+        });
+    });
+
+    test('should allow testing an AI provider', async () => {
+        const spy = vi.spyOn(Resources, 'task');
+        spy.mockImplementation((_) =>
+            Promise.resolve(_.callback!({ ok: true, latency_ms: 1200 }) as any),
+        );
+
+        const result = await SERVICE.testSignageAIProvider('provider-123');
+
+        expect(result.ok).toBe(true);
+        expect(result.latency_ms).toBe(1200);
+        expect(spy).toHaveBeenCalledWith({
+            id: 'provider-123',
+            task_name: 'test',
+            method: 'post',
+            path: 'signage/ai/providers',
+            callback: expect.any(Function),
+        });
+    });
+});


### PR DESCRIPTION
Part of the AI signage feature (PPT-2741). No ordering constraint: it can merge whenever, and nothing currently in the tree depends on it.

## What this adds

Client functions and types for the signage AI endpoints added in PlaceOS/rest-api#447: generate, edit, claim, job query and show, cancel, the provider CRUD, the provider test, capabilities, and usage.

## Notes for review

One deviation worth a decision. A persisted resource in this repo usually comes back as a model class built by a `process` function, and roughly 35 endpoint families do that. `SignageAIProvider` here is a plain interface instead. I went looking for a precedent for the interface approach and did not find one, so this is inconsistent rather than justified. It is a small change to make it a class if you would rather it matched.

## Testing

569 tests pass, build is clean.
